### PR TITLE
Fix broken destination paths with expanded mappings

### DIFF
--- a/tasks/sync.js
+++ b/tasks/sync.js
@@ -51,7 +51,13 @@ module.exports = function(grunt) {
     promise.all(this.files.map(function(fileDef) {
       var cwd = fileDef.cwd ? fileDef.cwd : '.';
       return promise.all(fileDef.src.map(function(src){
-        return processPair(path.join(cwd, src), path.join(fileDef.dest, src));
+        var dest = path.join(fileDef.dest, src);
+        // when using expanded mapping dest is the destination file
+        // not the destination folder
+        if(fileDef.orig.expand) {
+          dest = fileDef.dest;
+        }
+        return processPair(path.join(cwd, src), dest);
       }));      
     })).then(function(promises) {
       promise.all(promises).then(done);


### PR DESCRIPTION
When using expanding mappings the `file.dest` refers a destination file name, rather than the usual destination directory which was previously assumed.

This results is weirdly nested destination directories.
