### PR TITLE
the grunt.log calls can be very abundant...

### DIFF
--- a/tasks/sync.js
+++ b/tasks/sync.js
@@ -5,14 +5,14 @@ var path = require('path');
 module.exports = function(grunt) {
 
   var overwriteDest = function(src, dest) {
-      grunt.log.writeln('Overwriting ' + dest.cyan + 'because type differs.');
+      grunt.verbose.writeln('Overwriting ' + dest.cyan + 'because type differs.');
       grunt.file['delete'](dest);
       grunt.file.copy(src, dest);
     };
   var updateIfNeeded = function(src, dest, srcStat, destStat) {
       // we can now compare modification dates of files
       if(srcStat.mtime.getTime() > destStat.mtime.getTime()) {
-        grunt.log.writeln('Updating file ' + dest.cyan);
+        grunt.verbose.writeln('Updating file ' + dest.cyan);
         // and just update destination
         grunt.file.copy(src, dest);
       }


### PR DESCRIPTION
the grunt.log calls can be very abundant and obfuscate important log messages when dealing with a large number of files IMHO.
I would suggest to replace those 2 references with grunt.verbose.
