### PR TITLE
Bump version, bump required engines.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-sync",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-sync",
   "description": "Task to synchronize two directories. Similar to grunt-copy but updates only files that have been changed.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "homepage": "https://github.com/tomusdrw/grunt-sync.git",
   "author": {
     "name": "Tomasz Drwiega",
@@ -19,7 +19,7 @@
   "main": "Gruntfile.js",
   "readmeFilename": "readme.md",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6 <7 || >=8"
   },
   "scripts": {
     "lint": "semistandard",


### PR DESCRIPTION
Resolves #61 

I've copied requirements of `fs-extra`, since they were the most restrictive compared to other dependencies.