### PR TITLE
Update dependencies to caret for more leniency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-sync",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-sync",
   "description": "Task to synchronize two directories. Similar to grunt-copy but updates only files that have been changed.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "homepage": "https://github.com/tomusdrw/grunt-sync.git",
   "author": {
     "name": "Tomasz Drwiega",
@@ -27,9 +27,9 @@
     "grunt": "grunt"
   },
   "dependencies": {
-    "fs-extra": "6.0.1",
-    "glob": "7.0.5",
-    "md5-file": "2.0.3"
+    "fs-extra": "^6.0.1",
+    "glob": "^7.0.5",
+    "md5-file": "^2.0.3"
   },
   "devDependencies": {
     "chai": "4.1.2",


### PR DESCRIPTION
One of the latest versions removed these carets. Adding them back to allow for package managers more freedom to deduplicate packages more aggressively